### PR TITLE
Check aHandlers to avoid [undefined] or [null] or [0]...

### DIFF
--- a/js/helpers/OTHelper.js
+++ b/js/helpers/OTHelper.js
@@ -269,7 +269,7 @@
       var apiKey = _sessionInfo.apiKey;
       var sessionId = _sessionInfo.sessionId;
       var token = _sessionInfo.token;
-      if (!Array.isArray(aHandlers)) {
+      if (aHandlers && !Array.isArray(aHandlers)) {
         aHandlers = [aHandlers];
       }
       return otLoaded.then(function() {


### PR DESCRIPTION
otherwise aHandlers returns true always below

aHandlers && _setHandlers(self, self.session, aHandlers);