### PR TITLE
IE-922 - Subscriber's events are assigned before the subscriber initalization is finished

### DIFF
--- a/js/helpers/OTHelper.js
+++ b/js/helpers/OTHelper.js
@@ -601,6 +601,7 @@
           _session.subscribe(aStream, aTargetElement, aProperties, function(error) {
             error ? reject(error) : resolve(subscriber);
           });
+      }).then(function(subscriber) {
         Object.keys(aHandlers).forEach(function(name) {
           subscriber.on(name, aHandlers[name].bind(self));
         });
@@ -610,7 +611,7 @@
           subscriber.off();
           endAnnotation(subscriber);
         });
-      }).then(function(subscriber) {
+
         aTargetElement.dataset.videoDimensions = JSON.stringify(aStream.videoDimensions);
         aTargetElement.dataset.videoType = aStream.videoType;
         runningSubs--;


### PR DESCRIPTION
The events are assigned to the Subscriber calling the method .on before the Subscriber initialization has been finished.

So, when the audioLevelUpdated event listener is added, opentok.js Subscriber's _audioLevelRunner is not initialized yet and it is not started:

```
    if (_audioLevelCapable) {
      this.on({
        'audioLevelUpdated:added': function audioLevelUpdatedAdded() {
          if (_audioLevelRunner) {
            _audioLevelRunner.start();
          }
```
This provokes that the audioLevelUpdated event is never sent.

The solution is to wait for the subscriber initialization to assign the events.